### PR TITLE
合并分支 'unix'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,28 @@
 # RobinPlayer
+
 在控制台播放《使一颗心免于哀伤》
 
-## 如何运行本程序
-1. 确保系统为 **Windows 10** 及以上版本。
-1. 从 [Release](https://github.com/SyrieYume/RobinPlayer/releases) 下载 `RobinPlayer.exe`，或者下载源代码 `main.c` 手动编译。
-2. 双击运行程序。
-3. 将终端窗口调整到合适大小。
-4. 尽情欣赏这首《使一颗心免于哀伤》吧！
+这个分支是 Unix 版本，Winows 版本请查看 main 分支
 
+## 如何使用
 
-## 如何编译本项目
-使用的编译器为 **MinGW** (gcc version 14.2.0)
-```bash
-gcc -o RobinPlayer.exe main.c
-```
+1. 安装依赖
 
-## 编译注意事项
-1. 使用C语言编译器，而不是C++编译器 (**Visual Studio** 中需要将源文件后缀名改为 `.c` 而不是 `.cpp`)。
-2. 在 Visual Studio 上编译的时候，需要在 `"项目"->"属性"->"C/C++"->"命令行"->"其他选项"` 中加入`/utf-8`,否则可能会出现乱码。
-3. 不要直接复制粘贴代码到 Visual Studio，否则排版可能会乱，并且可能会出现编码问题。
-4. 如果出现编译错误`C2001:常量中有换行符`，需要在Visual Studio的 **高级保存选项** 中将编码改为`Unicode(UTF-8 带签名)-代码页65001`。
-   
-   打开**高级保存选项**的方法：
-   工具 -> 自定义 -> 命令，在"菜单栏"项选择"文件"，点击"添加命令"，在"类别栏"中选择"文件"，在"命令栏"中找到"高级保存选项"，单击"确定"保存。在 Viusal Studio 主界面工具栏的"文件"中即可找到高级保存选项。
+   ```bash
+   sudo apt-get update && sudo apt-get install libsdl2-dev libsdl2-mixer-dev
+   ```
+
+2. 下载并编译
+
+   ```bash
+   git clone https://github.com/SyrieYume/RobinPlayer.git
+   cd RobinPlayer
+   git checkout unix
+   gcc -o main main.c -lSDL2 -lSDL2_mixer
+   ```
+
+3. 运行
+
+   ```bash
+   ./main
+   ```

--- a/README.md
+++ b/README.md
@@ -2,9 +2,50 @@
 
 在控制台播放《使一颗心免于哀伤》
 
-这个分支是 Unix 版本，Winows 版本请查看 main 分支
+## 项目结构
 
-## 如何使用
+**`main.c`** : 最终程序 RobinPlayer.exe 的代码  
+
+**`res`** : 项目使用到的资源文件
+
+**`Generator/bmp_to_binary.c`** : 将 彩色BMP图片 转换为 二值图 的程序代码  
+
+**`Generator/files_to_base64.c`** : 将 文件 转换为 base64字符串 的程序代码  
+
+**`Generator/base64_to_img.c`** : 将 base64字符串 转换为 字符画代码 的程序代码  
+
+**`win.h` 和 `unix.h`** : 平台相关的代码，用于处理不同平台的终端控制、音频播放和时间获取
+
+## 如何运行本程序
+
+### Windows 10 及以上版本
+
+#### 从可执行文件
+
+1. 从 [Release](https://github.com/SyrieYume/RobinPlayer/releases) 下载 `RobinPlayer.exe`。
+2. 双击运行程序。
+3. 将终端窗口调整到合适大小。
+4. 尽情欣赏这首《使一颗心免于哀伤》吧！
+
+#### 从源代码
+
+使用的编译器为 **MinGW** (gcc version 14.2.0)
+
+```bash
+gcc -o RobinPlayer.exe main.c
+```
+
+⚠ **编译注意事项**
+
+1. 使用C语言编译器，而不是C++编译器 (**Visual Studio** 中需要将源文件后缀名改为 `.c` 而不是 `.cpp`)。
+2. 在 Visual Studio 上编译的时候，需要在 `"项目"->"属性"->"C/C++"->"命令行"->"其他选项"` 中加入`/utf-8`,否则可能会出现乱码。
+3. 不要直接复制粘贴代码到 Visual Studio，否则排版可能会乱，并且可能会出现编码问题。
+4. 如果出现编译错误`C2001:常量中有换行符`，需要在Visual Studio的 **高级保存选项** 中将编码改为`Unicode(UTF-8 带签名)-代码页65001`。
+   
+   打开 **高级保存选项** 的方法：
+   工具 -> 自定义 -> 命令，在"菜单栏"项选择"文件"，点击"添加命令"，在"类别栏"中选择"文件"，在"命令栏"中找到"高级保存选项"，单击"确定"保存。在 Viusal Studio 主界面工具栏的"文件"中即可找到高级保存选项。
+
+### Unix/Linux
 
 1. 安装依赖
 
@@ -16,13 +57,11 @@
 
    ```bash
    git clone https://github.com/SyrieYume/RobinPlayer.git
-   cd RobinPlayer
-   git checkout unix
-   gcc -o main main.c -lSDL2 -lSDL2_mixer
+   gcc -o RobinPlayer main.c -lSDL2 -lSDL2_mixer
    ```
 
 3. 运行
 
    ```bash
-   ./main
+   ./RobinPlayer
    ```

--- a/main.c
+++ b/main.c
@@ -1,4 +1,5 @@
 #define _CRT_SECURE_NO_WARNINGS 1
+// clang-format off
 const char *s =                                                                                                                                                                                            "TVRoZA"                                                                                                         
                                                                                                                                                                                          "AAAA"                                                                                                             
                                                                                                                                                                                                                                                                                                             
@@ -252,16 +253,22 @@ const char *s =                                                                 
 "4ssD4tsj4utD4xuEI3si4gpzk10KW317/jtYW1oF+KpGKHq2uLqm+Ko2mDn2iClWV8i192h1xyiF50hV5xhV1xkmR7o3KLkGZ+gFlyhFt2il56lmaEmWaJjlyChlF4i1iOnny2t5KxsWBfoCIJpisRojMfnTEcmTAamC8ZlzEajy8ZiCoWhigXgycVgCYWfyUXfiQXfSMWgCQXgiYZgCMVhCcVjCwakC4bkS8bjiwaki4bli8cmTEfoTMht0IltjshrCkSgSAcrZa9//////v/tZ/Pc1ehi2exiWOuhF6jci"
 "YTeCgUdicUdScUdScUdCYUciYUdCYUdCYTdSYVdykaeC0cfDUhgTsogTsngjkigjccfjEVfC8TfTAUfDAXfTAYgDEafC4aeiwYeCkXeCcXdyYXeScXeScXeSgXeCcWgioZgywafCgVgikYgSsYgSsZgiwagi0bgy4bhC4chi4chy4diS4eii4ejC8gkTEilzQkmTQlnTQpniUYlBsRrV5gwI6eqnWam16Gl1p9k1t6mF98jVt0hVhwiVxxiVxzi150j2F3jWB2h1xyiV51jGB5il94jmF8kGCAhlh6flB0fU"
 "9zg1N9jFx+mVdbiCUWfA8BgiMVfSMWeyITeiIUeCETeCMUeSMSdB4Rcx4TcRwRbhsQbhsRcB0RcR8Rch8VcR8WciAVcyEWdCEXdSAVeyUWgSgXgicXhCkYhywYji4amDEbqUEgtEkrtEE5qSwjfx4XqIWi9ubz59HvjHGtgF6liGWwg1yeAAA=";
-
+// clang-format on
 #include <stdio.h>
 #include <io.h>
 #include <windows.h>
 #include <time.h>
 
-#define error(message) { printf(message "\n"); fflush(stdout); system("pause"); exit(-1); }
+#define error(message)        \
+    {                         \
+        printf(message "\n"); \
+        fflush(stdout);       \
+        system("pause");      \
+        exit(-1);             \
+    }
 
 #ifndef MIN
-#define MIN(a,b) (((a) < (b)) ? (a) : (b))
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #endif
 
 #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
@@ -275,30 +282,27 @@ const char *s =                                                                 
 
 #define FRAME_WIDTH 120
 #define FRAME_HEIGHT 30
-#define DELAY 1000  // 歌词播放延迟，用于让歌词与声音对齐
-#define CHARACTER "#"   // 在控制台用来显示图片的字符
-
-
+#define DELAY 1000    // 歌词播放延迟，用于让歌词与声音对齐
+#define CHARACTER "#" // 在控制台用来显示图片的字符
 
 #pragma pack(1)
-typedef struct {
+typedef struct
+{
     unsigned char B, G, R;
 } Pixel, ColorBGR;
 
-
-typedef struct {
+typedef struct
+{
     int width, height;
-    Pixel* pixels;
+    Pixel *pixels;
 } BitmapImage;
 
-
-typedef struct {
+typedef struct
+{
     int time;
     char lyric[100];
     char translation[100];
 } LyricLine;
-
-
 
 char strBuffer[(FRAME_WIDTH + 1) * (FRAME_HEIGHT + 1) * 24]; // 字符缓冲
 
@@ -306,29 +310,28 @@ HANDLE hConsole; // 控制台句柄
 
 BitmapImage pic1, pic2; // 两张图片
 
-LyricLine* lyrics; // 歌词数据
+LyricLine *lyrics; // 歌词数据
 int lyricLineNums; // 歌词的行数
 
-
-
-
 // Base64编码和解码表
-const char* encode_table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-const char* decode_table = "                                           \x3e   \x3f\x34\x35\x36\x37\x38\x39\x3a\x3b\x3c\x3d       \x0\x1\x2\x3\x4\x5\x6\x7\x8\x9\xa\xb\xc\xd\xe\xf\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19      \x1a\x1b\x1c\x1d\x1e\x1f\x20\x21\x22\x23\x24\x25\x26\x27\x28\x29\x2a\x2b\x2c\x2d\x2e\x2f\x30\x31\x32\x33     ";
+const char *encode_table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+const char *decode_table = "                                           \x3e   \x3f\x34\x35\x36\x37\x38\x39\x3a\x3b\x3c\x3d       \x0\x1\x2\x3\x4\x5\x6\x7\x8\x9\xa\xb\xc\xd\xe\xf\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19      \x1a\x1b\x1c\x1d\x1e\x1f\x20\x21\x22\x23\x24\x25\x26\x27\x28\x29\x2a\x2b\x2c\x2d\x2e\x2f\x30\x31\x32\x33     ";
 
 // base64字符串解码
-BYTE* base64_decode(const char* source_str, int source_str_length, int* decoded_data_size) {
-    
+BYTE *base64_decode(const char *source_str, int source_str_length, int *decoded_data_size)
+{
+
     // 计算解码后数据的大小
     *decoded_data_size = source_str_length * 3 / 4;
 
     // 申请内存空间
-    BYTE* decoded_data = (BYTE*)malloc(sizeof(BYTE) * (*decoded_data_size + 1));
-    BYTE* decoded_ptr = decoded_data;
+    BYTE *decoded_data = (BYTE *)malloc(sizeof(BYTE) * (*decoded_data_size + 1));
+    BYTE *decoded_ptr = decoded_data;
 
     // 首先，4个字符一组，进行解码
     int n = (source_str_length + 3) / 4 - 1;
-    for (int i = 0; i < n; ++i) {
+    for (int i = 0; i < n; ++i)
+    {
         char d1 = decode_table[source_str[0]], d2 = decode_table[source_str[1]],
              d3 = decode_table[source_str[2]], d4 = decode_table[source_str[3]];
         decoded_ptr[0] = (d1 << 2) | (d2 >> 4);
@@ -340,8 +343,10 @@ BYTE* base64_decode(const char* source_str, int source_str_length, int* decoded_
 
     // 对剩下的字符进行解码
     n = source_str_length - 4 * n - 1;
-    while (n > 0) {
-        if (source_str[1] == encode_table[64]) break;
+    while (n > 0)
+    {
+        if (source_str[1] == encode_table[64])
+            break;
         *decoded_ptr = decode_table[source_str[0]] << (8 - n * 2) | decode_table[source_str[1]] >> (n * 2 - 2);
         decoded_ptr++;
         source_str++;
@@ -354,41 +359,41 @@ BYTE* base64_decode(const char* source_str, int source_str_length, int* decoded_
     return decoded_data;
 }
 
-
-
-
 // 解码出4个文件的数据，并且写入文件
-void decodeDatas() {
-    const char* files[] = { MID_FILE_PATH, LYRIC_FILE_PATH, PIC1_PATH, PIC2_PATH };
-    int lengths[] = { 14016, 3244, 5484, 14476 };
+void decodeDatas()
+{
+    const char *files[] = {MID_FILE_PATH, LYRIC_FILE_PATH, PIC1_PATH, PIC2_PATH};
+    int lengths[] = {14016, 3244, 5484, 14476};
 
-    const char* base64_ptr = s;
+    const char *base64_ptr = s;
 
-    for (int i = 0; i < 4; base64_ptr += lengths[i], i++) {
+    for (int i = 0; i < 4; base64_ptr += lengths[i], i++)
+    {
         // 判断文件存在，就跳过这个文件
         if (_access(files[i], 0) == 0)
             continue;
 
-        FILE* fp;
+        FILE *fp;
         fopen_s(&fp, files[i], "wb");
 
-        if (fp) {
+        if (fp)
+        {
             int dataSize;
-            BYTE* data = base64_decode(base64_ptr, lengths[i], &dataSize);
-            
+            BYTE *data = base64_decode(base64_ptr, lengths[i], &dataSize);
+
             fwrite(data, sizeof(BYTE), dataSize, fp);
-            
+
             free(data);
             fclose(fp);
         }
-        else error("写入文件时出错！");
+        else
+            error("写入文件时出错！");
     }
 }
 
-
-
 // 开启Windows的虚拟终端序列支持
-BOOLEAN enableVTMode() {
+BOOLEAN enableVTMode()
+{
     HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
     if (hOut == INVALID_HANDLE_VALUE)
         return FALSE;
@@ -404,23 +409,19 @@ BOOLEAN enableVTMode() {
     return TRUE;
 }
 
-
-
-
 // 设置控制台的光标到 (x, y)
-void setCursorPos(int x, int y) {
+void setCursorPos(int x, int y)
+{
     COORD coord;
     coord.X = x;
     coord.Y = y;
     SetConsoleCursorPosition(hConsole, coord);
 }
 
-
-
-
 // 读取Bitmap图片
-BOOLEAN readBitmap(const char* filePath, BitmapImage* image) {
-    FILE* fp = fopen(filePath, "rb");
+BOOLEAN readBitmap(const char *filePath, BitmapImage *image)
+{
+    FILE *fp = fopen(filePath, "rb");
     if (!fp)
         return FALSE;
 
@@ -433,12 +434,12 @@ BOOLEAN readBitmap(const char* filePath, BitmapImage* image) {
     int height = infoHeader.biHeight;
 
     // 读取Bitmap图片的数据
-    Pixel* pixels = (Pixel*)malloc(sizeof(Pixel) * width * height);
+    Pixel *pixels = (Pixel *)malloc(sizeof(Pixel) * width * height);
     fread(pixels, sizeof(Pixel), width * height, fp);
     fclose(fp);
 
     // Bitmap图片的行顺序是上下颠倒的，这里把它颠倒回来
-    Pixel* temp = (Pixel*)malloc(sizeof(Pixel) * width * height);
+    Pixel *temp = (Pixel *)malloc(sizeof(Pixel) * width * height);
     for (int y = 0; y < height; y++)
         memcpy(temp + y * width, pixels + (height - y - 1) * width, width * sizeof(Pixel));
     free(pixels);
@@ -451,10 +452,9 @@ BOOLEAN readBitmap(const char* filePath, BitmapImage* image) {
     return TRUE;
 }
 
-
-
 // 在(posX, posY)处打印图片
-void displayImage(BitmapImage image, int posX, int posY) {
+void displayImage(BitmapImage image, int posX, int posY)
+{
     int bufferIndex = 0;
     int x, y;
     int displayWidth = MIN(FRAME_WIDTH - posX, image.width);
@@ -462,13 +462,15 @@ void displayImage(BitmapImage image, int posX, int posY) {
 
     bufferIndex += sprintf_s(strBuffer + bufferIndex, sizeof(strBuffer), "\033[0m");
 
-    for (y = 0; y < displayHeight; y++) {
+    for (y = 0; y < displayHeight; y++)
+    {
 
         // 打印posX个空格，用来占位
         for (x = 0; x < posX; x++)
             strBuffer[bufferIndex++] = ' ';
 
-        for (x = 0; x < displayWidth; x++) {
+        for (x = 0; x < displayWidth; x++)
+        {
             Pixel pixel = image.pixels[x + y * image.width];
 
             // 在像素值为纯黑的地方打印空格(相当于透明)
@@ -482,20 +484,18 @@ void displayImage(BitmapImage image, int posX, int posY) {
     }
 
     strBuffer[bufferIndex] = '\0';
-    
+
     setCursorPos(0, posY);
     printf(strBuffer);
     fflush(stdout);
 }
 
-
-
-
 // 调用Windows的API播放mid音频 (ps: 这个API用来播放mp3音乐也是可以的~)
-BOOLEAN playMusic(const char* filePath) {
+BOOLEAN playMusic(const char *filePath)
+{
     HMODULE module = LoadLibraryA("winmm.dll");
 
-    typedef MCIERROR(WINAPI* MciSendStringT)(LPCSTR lpstrCommand, LPSTR lpstrReturnString, UINT uReturnLength, HWND hwndCallback);
+    typedef MCIERROR(WINAPI * MciSendStringT)(LPCSTR lpstrCommand, LPSTR lpstrReturnString, UINT uReturnLength, HWND hwndCallback);
 
     MciSendStringT func_mciSendStringA = (MciSendStringT)GetProcAddress(module, "mciSendStringA");
     if (func_mciSendStringA == NULL)
@@ -513,12 +513,10 @@ BOOLEAN playMusic(const char* filePath) {
     return TRUE;
 }
 
-
-
-
 // 读取歌词文件数据
-BOOLEAN readLyricFile(const char* filePath, LyricLine** lyrics, int* lineNums) {
-    FILE* fp;
+BOOLEAN readLyricFile(const char *filePath, LyricLine **lyrics, int *lineNums)
+{
+    FILE *fp;
     fopen_s(&fp, filePath, "r");
 
     if (!fp)
@@ -528,13 +526,16 @@ BOOLEAN readLyricFile(const char* filePath, LyricLine** lyrics, int* lineNums) {
     int minutes, seconds, milliseconds;
     int size = 10, i = 0;
 
-    LyricLine* _lyrics = (LyricLine*)malloc(sizeof(LyricLine) * size);
+    LyricLine *_lyrics = (LyricLine *)malloc(sizeof(LyricLine) * size);
 
-    while (fgets(line, 200, fp)) {
-        if (sscanf_s(line, "[%02d:%02d.%03d]%[^(] (%[^)])", &minutes, &seconds, &milliseconds, lyric, 100, translation, 100) == 5) {
-            if (i == size) {
+    while (fgets(line, 200, fp))
+    {
+        if (sscanf_s(line, "[%02d:%02d.%03d]%[^(] (%[^)])", &minutes, &seconds, &milliseconds, lyric, 100, translation, 100) == 5)
+        {
+            if (i == size)
+            {
                 size += 10;
-                _lyrics = (LyricLine*)realloc(_lyrics, sizeof(LyricLine) * size);
+                _lyrics = (LyricLine *)realloc(_lyrics, sizeof(LyricLine) * size);
             }
 
             _lyrics[i].time = minutes * 60000 + seconds * 1000 + milliseconds;
@@ -551,14 +552,12 @@ BOOLEAN readLyricFile(const char* filePath, LyricLine** lyrics, int* lineNums) {
     return TRUE;
 }
 
-
-
-
 // 彩蛋
-void surprise() {
+void surprise()
+{
     // 生成一个随机打乱的排序列表
     int len = pic2.width * pic2.height;
-    int* order = (int*)malloc(sizeof(int) * len);
+    int *order = (int *)malloc(sizeof(int) * len);
 
     srand(time(NULL));
     int i, j, tmp;
@@ -566,7 +565,8 @@ void surprise() {
     for (i = 0; i < len; ++i)
         order[i] = i;
 
-    for (i = len - 1; i > 0; --i) {
+    for (i = len - 1; i > 0; --i)
+    {
         j = rand() % (i + 1);
         tmp = order[i];
         order[i] = order[j];
@@ -574,7 +574,8 @@ void surprise() {
     }
 
     // 按照随机的像素点顺序显示彩蛋
-    for (i = 0; i < len; i++) {
+    for (i = 0; i < len; i++)
+    {
         int pos = order[i];
 
         Pixel pixel = pic2.pixels[pos];
@@ -586,23 +587,23 @@ void surprise() {
         if (i % FRAME_WIDTH == 0)
             Sleep(50);
     }
-
 }
 
-
-
 // 播放歌词
-void playLyrics(LyricLine* lyrics, int lineNums) {
+void playLyrics(LyricLine *lyrics, int lineNums)
+{
     clock_t startTime = clock() + DELAY;
 
-    for (int i = 0; i < lineNums; ++i) {
-        
+    for (int i = 0; i < lineNums; ++i)
+    {
+
         // 等待到第i行歌词的播放时间
-        while (clock() < lyrics[i].time + startTime) {
+        while (clock() < lyrics[i].time + startTime)
+        {
             Sleep(100);
         }
 
-        // j表示打印歌词的开始行数，end表示打印歌词的结束行数，默认为打印 第i-4行 到 第i+3行 的7行歌词 
+        // j表示打印歌词的开始行数，end表示打印歌词的结束行数，默认为打印 第i-4行 到 第i+3行 的7行歌词
         int j = i - 4, end = i + 3;
 
         // 第i行歌词的高亮颜色，默认为知更鸟色
@@ -611,28 +612,33 @@ void playLyrics(LyricLine* lyrics, int lineNums) {
         color.G = 156;
         color.R = 131;
 
-        if (i < 8) {
+        if (i < 8)
+        {
             j = 0;
             end = i;
         }
 
-        else if (i < 11) {
+        else if (i < 11)
+        {
             j = i + i - 14;
             end = i + i - 7;
         }
 
-        else if (i < 22) {
+        else if (i < 22)
+        {
             j = i - 4;
             end = MIN(end, lineNums - 1);
         }
 
         // 彩蛋
-        else if (i == 22) {
+        else if (i == 22)
+        {
             surprise();
             continue;
         }
 
-        else if (i > 22) {
+        else if (i > 22)
+        {
             j = i;
             end = i;
             color.B = 155;
@@ -640,10 +646,10 @@ void playLyrics(LyricLine* lyrics, int lineNums) {
             color.R = 178;
         }
 
-
         // 将要打印的所有歌词写入缓冲区，然后用puts一次全部打印出来
         int bufferIndex = 0;
-        for (; j <= end; j++) {
+        for (; j <= end; j++)
+        {
             if (j == i)
                 bufferIndex += sprintf_s(strBuffer + bufferIndex, sizeof(strBuffer) - bufferIndex, "\033[1m\033[38;2;%d;%d;%dm%-50s\n%-50s\n\n\033[0m", color.R, color.G, color.B, lyrics[j].lyric, lyrics[j].translation);
             else
@@ -658,15 +664,12 @@ void playLyrics(LyricLine* lyrics, int lineNums) {
     }
 }
 
-
-
-
-int main() {
+int main()
+{
 
     // 设置控制台编码方式为utf-8
     system("chcp 65001");
     SetConsoleOutputCP(CP_UTF8);
-
 
     // 设置控制台字体为黑体，防止出现乱码
     CONSOLE_FONT_INFOEX cfi;
@@ -677,22 +680,18 @@ int main() {
 
     SetCurrentConsoleFontEx(GetStdHandle(STD_OUTPUT_HANDLE), FALSE, &cfi);
 
-
     // 获取控制台的HANDLE
     hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
     if (hConsole == INVALID_HANDLE_VALUE)
         error("获取控制台句柄失败！");
 
-
     // 启用Windows虚拟终端序列支持
     if (!enableVTMode())
         error("无法开启终端虚拟序列支持！");
 
-
     system("mode con cols=121 lines=31"); // 设置控制台大小
-    printf("\033[0m\n"); // 清除文字样式
-    printf("\033[?25l\n"); // 隐藏光标
-
+    printf("\033[0m\n");                  // 清除文字样式
+    printf("\033[?25l\n");                // 隐藏光标
 
     // 解码数据
     decodeDatas();
@@ -722,7 +721,7 @@ int main() {
     free(pic2.pixels);
 
     system("pause");
-    
+
     printf("\033[0m\n"); // 清除文字样式
     return 0;
 }

--- a/unix.h
+++ b/unix.h
@@ -1,0 +1,80 @@
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_mixer.h>
+#define __USE_XOPEN_EXTENDED
+#include <unistd.h>
+#include <signal.h>
+
+#define error(message)        \
+    {                         \
+        printf(message "\n"); \
+        fflush(stdout);       \
+        getchar();            \
+        exit(-1);             \
+    }
+
+// 一些 Windows 独有的数据类型
+typedef unsigned char BYTE;
+typedef int BOOLEAN;
+#define FALSE 0
+#define TRUE 1
+
+// 停止信号, 用来响应 ^C （SIGINT）信号
+volatile sig_atomic_t stop = 0;
+void handle_sigint(int sig)
+{
+    stop = 1;
+}
+
+// 用于响应停止信号的宏
+#define RESPONSE_STOP \
+    if (stop)         \
+        break;
+
+// 使用 SDL_mixer 播放音乐
+// 需要在编译时链接 -lSDL2 -lSDL2_mixer
+// 需要在主程序退出前调用 Mix_CloseAudio() 和 SDL_Quit() 来清理资源
+BOOLEAN playMusic(const char *filePath)
+{
+    if (SDL_Init(SDL_INIT_AUDIO) < 0)
+    {
+        fprintf(stderr, "无法初始化 SDL: %s\n", SDL_GetError());
+        return 0;
+    }
+
+    // 初始化 SDL_mixer
+    if (Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 2048) < 0)
+    {
+        fprintf(stderr, "无法初始化 SDL_mixer: %s\n", Mix_GetError());
+        SDL_Quit();
+        return 0;
+    }
+
+    // 加载 MP3 文件
+    Mix_Music *music = Mix_LoadMUS(filePath);
+    if (music == NULL)
+    {
+        fprintf(stderr, "无法加载音频文件: %s\n", Mix_GetError());
+        Mix_CloseAudio();
+        SDL_Quit();
+        return 0;
+    }
+
+    // 播放音乐
+    if (Mix_PlayMusic(music, 1) == -1)
+    {
+        fprintf(stderr, "无法播放音频: %s\n", Mix_GetError());
+        Mix_FreeMusic(music);
+        Mix_CloseAudio();
+        SDL_Quit();
+        return 0;
+    }
+
+    return 1;
+}
+
+// 设置控制台的光标到 (x, y)
+void setCursorPos(int x, int y)
+{
+    printf("\033[%d;%dH", y + 1, x + 1);
+    fflush(stdout);
+}

--- a/win.h
+++ b/win.h
@@ -13,8 +13,8 @@
 HANDLE hConsole; // 控制台句柄
 
 // 时钟相关，转为 Windows 下的 Sleep 函数
-#define usleep(ns) Sleep(ns / 1000000)
-#define sleep(s) Sleep(s)
+#define usleep(ns) Sleep(ns / 1000000) // 以微秒为单位, 1s = 1000000us
+#define sleep(s) Sleep(s)              // 以秒为单位
 
 // 开启Windows的虚拟终端序列支持
 BOOLEAN enableVTMode()

--- a/win.h
+++ b/win.h
@@ -1,0 +1,75 @@
+#include <io.h>
+#include <windows.h>
+
+// 因为使用了 pause，所以这个宏也是平台相关的
+#define error(message)        \
+    {                         \
+        printf(message "\n"); \
+        fflush(stdout);       \
+        system("pause");      \
+        exit(-1);             \
+    }
+
+HANDLE hConsole; // 控制台句柄
+
+// 时钟相关，转为 Windows 下的 Sleep 函数
+#define usleep(ns) Sleep(ns / 1000000)
+#define sleep(s) Sleep(s)
+
+// 开启Windows的虚拟终端序列支持
+BOOLEAN enableVTMode()
+{
+#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x4
+#endif
+    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (hOut == INVALID_HANDLE_VALUE)
+        return FALSE;
+
+    DWORD dwMode = 0;
+    if (!GetConsoleMode(hOut, &dwMode))
+        return FALSE;
+
+    dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    if (!SetConsoleMode(hOut, dwMode))
+        return FALSE;
+
+    return TRUE;
+}
+
+// 设置控制台的光标到 (x, y)
+void setCursorPos(int x, int y)
+{
+    COORD coord;
+    coord.X = x;
+    coord.Y = y;
+    SetConsoleCursorPosition(hConsole, coord);
+}
+
+// 调用Windows的API播放mid音频 (ps: 这个API用来播放mp3音乐也是可以的~)
+BOOLEAN playMusic(const char *filePath)
+{
+    HMODULE module = LoadLibraryA("winmm.dll");
+
+    typedef MCIERROR(WINAPI * MciSendStringT)(LPCSTR lpstrCommand, LPSTR lpstrReturnString, UINT uReturnLength, HWND hwndCallback);
+
+    MciSendStringT func_mciSendStringA = (MciSendStringT)GetProcAddress(module, "mciSendStringA");
+    if (func_mciSendStringA == NULL)
+        return FALSE;
+
+    char buff[255], command[100];
+
+    sprintf_s(command, 100, "open %s alias playsound_134", filePath);
+    func_mciSendStringA(command, buff, 254, NULL);
+
+    sprintf_s(command, 100, "set playsound_134 time format milliseconds");
+    func_mciSendStringA(command, buff, 254, NULL);
+
+    sprintf_s(command, 100, "status playsound_134 length");
+    func_mciSendStringA(command, buff, 254, NULL);
+
+    sprintf_s(command, 100, "play playsound_134 from 0 to %s", buff);
+    func_mciSendStringA(command, buff, 254, NULL);
+
+    return TRUE;
+}


### PR DESCRIPTION
将平台相关的函数和依赖分离到了相应的头文件，并使用条件宏导入。

- Generator 下程序没有改，仍然只能在 windows 运行。
- 尽量没有动 Windows 原来的实现，除了：
    - 获取程序执行以来经过的时间：使用两次 time() 的差值，而不是 clock() ，因为后者在 unix 上无法确定秒数
    - 内存操作：去掉了所有 `_s`，sprinf_s strcpy_s 等等
    - 读取 bitmap 图片：使用等价但不太直观的代码读取尺寸并跳过头部